### PR TITLE
fix: compat with Create 6.0.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     runtimeOnly("mezz.jei:jei-1.21.1-neoforge:${jei_version}")
 
     implementation("com.simibubi.create:create-${minecraft_version}:${create_version}:slim") { transitive = false }
-    implementation("net.createmod.ponder:Ponder-NeoForge-${minecraft_version}:${ponder_version}")
+    implementation("net.createmod.ponder:ponder-neoforge:${ponder_version}")
     compileOnly("dev.engine-room.flywheel:flywheel-neoforge-api-${minecraft_version}:${flywheel_version}")
     runtimeOnly("dev.engine-room.flywheel:flywheel-neoforge-${minecraft_version}:${flywheel_version}")
     implementation("com.tterrag.registrate:Registrate:${registrate_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,12 +9,12 @@ parchment_minecraft_version=1.21.1
 parchment_mappings_version=2024.11.17
 minecraft_version=1.21.1
 minecraft_version_range=[1.21.1]
-neo_version=21.1.152
+neo_version=21.1.235
 loader_version_range=[1,)
-create_version = 6.0.6-98
-ponder_version = 1.0.59
-flywheel_version = 1.0.4
-registrate_version = MC1.21-1.3.0+62
+create_version = 6.0.10-281
+ponder_version = 1.0.82+mc1.21.1
+flywheel_version = 1.0.6
+registrate_version = MC1.21-1.3.0+67
 jei_version=19.22.0.315
 jade_version=15.10.2+neoforge
 

--- a/src/main/java/euphy/upo/create_cultivation/content/cultivation_base/CultivationBaseBlockEntity.java
+++ b/src/main/java/euphy/upo/create_cultivation/content/cultivation_base/CultivationBaseBlockEntity.java
@@ -140,7 +140,7 @@ public class CultivationBaseBlockEntity extends KineticBlockEntity {
                 }
 
                 for (ProcessingOutput output : results) {
-                    ItemStack rolled = output.rollOutput();
+                    ItemStack rolled = output.rollOutput(level.getRandom());
                     if (!rolled.isEmpty()) {
                         rolledResults.add(rolled);
                     }

--- a/src/main/java/euphy/upo/create_cultivation/content/recipes/CultivatingRecipeParams.java
+++ b/src/main/java/euphy/upo/create_cultivation/content/recipes/CultivatingRecipeParams.java
@@ -6,7 +6,6 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.simibubi.create.content.processing.recipe.ProcessingOutput;
 import com.simibubi.create.content.processing.recipe.ProcessingRecipeParams;
-import com.simibubi.create.foundation.fluid.FluidIngredient;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -14,6 +13,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,8 +31,8 @@ public class CultivatingRecipeParams extends ProcessingRecipeParams {
 
     public static final MapCodec<CultivatingRecipeParams> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
 
-            Codec.either(FluidIngredient.CODEC, Ingredient.CODEC).listOf().fieldOf("ingredients").forGetter(p -> {
-                List<Either<FluidIngredient, Ingredient>> ingredients = new ArrayList<>();
+            Codec.either(SizedFluidIngredient.NESTED_CODEC, Ingredient.CODEC).listOf().fieldOf("ingredients").forGetter(p -> {
+                List<Either<SizedFluidIngredient, Ingredient>> ingredients = new ArrayList<>();
                 p.ingredients.forEach(i -> ingredients.add(Either.right(i)));
                 p.fluidIngredients.forEach(i -> ingredients.add(Either.left(i)));
                 return ingredients;

--- a/src/main/java/euphy/upo/create_cultivation/datagen/CCRecipeProvider.java
+++ b/src/main/java/euphy/upo/create_cultivation/datagen/CCRecipeProvider.java
@@ -45,7 +45,7 @@ public class CCRecipeProvider extends ProcessingRecipeGen<CultivatingRecipeParam
 
 
     @Override
-    protected void buildRecipes(RecipeOutput consumer) {
+    public void buildRecipes(RecipeOutput consumer) {
 
         ShapedRecipeBuilder.shaped(RecipeCategory.DECORATIONS, CCBlocks.CULTIVATION_BASE.get())
                 .pattern("GDG")


### PR DESCRIPTION
Create 6.0.10 移除了 FluidIngredient，并更改了一些 API 签名。
修复了issue#3，升级了依赖并修复了编译错误，现在模组可以正常加载。
已在 Create 6.0.10 + NeoForge 21.1.235 环境下测试通过。
Create 6.0.10 dropped `FluidIngredient` and changed a few API signatures.
Fixed issue#3, Bumped deps and fixed the compilation errors, mod loads fine now.
Tested with Create 6.0.10 + NeoForge 21.1.235.